### PR TITLE
Remove an extra '/' in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-All documentation, code, communication and discussion in this repository are covered by the [W3C Code of Conduct](https://www.w3.org/policies/code-of-conduct//).
+All documentation, code, communication and discussion in this repository are covered by the [W3C Code of Conduct](https://www.w3.org/policies/code-of-conduct/).


### PR DESCRIPTION
Oops, I didn't apply [this suggestion](https://github.com/w3ctag/.github/pull/1#discussion_r2009096711) before merging #1 last week.